### PR TITLE
TGD-1242 fix route to the API for the swagger docs

### DIFF
--- a/src/main/resources/swagger-static/swagger-ui.js
+++ b/src/main/resources/swagger-static/swagger-ui.js
@@ -3735,7 +3735,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.responseInterceptor = parent.options.responseInterceptor || null;
   }
   this.authorizations = args.security;
-  this.basePath = parent.basePath || '/';
+  this.basePath = window.location.pathname.replace(/\/swagger\/?/gi, "") + window.location.search;
   this.clientAuthorizations = clientAuthorizations;
   this.consumes = args.consumes || parent.consumes || ['application/json'];
   this.produces = args.produces || parent.produces || ['application/json'];


### PR DESCRIPTION
So now it is a relative path and we shouldn't care to put API name in config.
